### PR TITLE
Respect service type in environment and pipeline variable patching, add dry run

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,12 @@ pippo -c <pippo.json> -p <program-id> -e <environment-id> log save --service <sv
 pippo -c <pippo.json> -p <program-id> -e <environment-id> log tail --service <svc> --log <log>
 ```
 
+### dry-run mode
+
+You can pass the flag `--dry-run` on the command line to preview the changes for
+* environment variables
+* pipeline variables
+
 ### CI mode
 
 Since updating running pipelines or environments that are currently updating is not possible pippo will normally wait until it is possible.

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -12,7 +12,9 @@ use crate::client::CloudManagerClient;
 use crate::config::CloudManagerConfig;
 use crate::encryption::{decrypt, encrypt};
 use crate::logs::{download_log, tail_log};
-use crate::models::{Domain, LogType, PipelineVariableServiceType, EnvironmentVariableServiceType, ServiceType};
+use crate::models::{
+    Domain, EnvironmentVariableServiceType, LogType, PipelineVariableServiceType, ServiceType,
+};
 use crate::variables::{
     get_env_vars, get_pipeline_vars, set_env_vars_from_file, set_pipeline_vars_from_file,
 };

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -207,7 +207,13 @@ pub async fn init_cli() {
             {
                 if let PipelineVarsCommands::Set { input } = &pipeline_vars_command {
                     println!("🚀 Patching pipeline variables from input file {}\n", input);
-                    set_pipeline_vars_from_file(input, &mut cm_client, cli.ci_mode, cli.dry_run_mode).await;
+                    set_pipeline_vars_from_file(
+                        input,
+                        &mut cm_client,
+                        cli.ci_mode,
+                        cli.dry_run_mode,
+                    )
+                    .await;
                     process::exit(0);
                 }
             }

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -71,7 +71,8 @@ pub async fn init_cli() {
                         "🚀 Patching environment variables from input file {}\n",
                         input
                     );
-                    set_env_vars_from_file(input, &mut cm_client, cli.ci_mode).await;
+                    set_env_vars_from_file(input, &mut cm_client, cli.ci_mode, cli.dry_run_mode)
+                        .await;
                     process::exit(0);
                 }
             }

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -207,7 +207,7 @@ pub async fn init_cli() {
             {
                 if let PipelineVarsCommands::Set { input } = &pipeline_vars_command {
                     println!("🚀 Patching pipeline variables from input file {}\n", input);
-                    set_pipeline_vars_from_file(input, &mut cm_client, cli.ci_mode).await;
+                    set_pipeline_vars_from_file(input, &mut cm_client, cli.ci_mode, cli.dry_run_mode).await;
                     process::exit(0);
                 }
             }

--- a/src/clap_models.rs
+++ b/src/clap_models.rs
@@ -35,6 +35,10 @@ pub struct Cli {
     #[clap(long = "ci", global = true, action = ArgAction::SetTrue )]
     pub ci_mode: bool,
 
+    /// Only log but to not apply any changes
+    #[clap(long = "dry-run", global = true, action = ArgAction::SetTrue )]
+    pub dry_run_mode: bool,
+
     #[clap(subcommand)]
     pub command: Option<Commands>,
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,6 @@
 use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use strum_macros::{EnumString, IntoStaticStr};
 
 // Common models used across multiple modules
@@ -49,8 +50,8 @@ pub struct Variable {
     pub value: Option<String>,
     #[serde(rename(deserialize = "type", serialize = "type"))]
     pub variable_type: VariableType,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub service: Option<String>,
+    #[serde(default = "VariableServiceType::all")]
+    pub service: VariableServiceType,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
 }
@@ -61,6 +62,29 @@ pub struct Variable {
 pub enum VariableType {
     String,
     SecretString,
+}
+
+/// Possible types that a service can have
+#[derive(Clone, Debug, Deserialize, Serialize, IntoStaticStr, EnumString, PartialEq, Eq)]
+#[strum(serialize_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
+pub enum VariableServiceType {
+    All,
+    Author,
+    Publish,
+    Preview,
+}
+
+impl fmt::Display for VariableServiceType {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "{}", format!("{:?}", self).to_lowercase())
+    }
+}
+
+impl VariableServiceType {
+    fn all() -> Self {
+        VariableServiceType::All
+    }
 }
 
 /// Model for the necessary JWT claims to retrieve an Adobe access token

--- a/src/models.rs
+++ b/src/models.rs
@@ -51,7 +51,7 @@ pub struct PipelineVariable {
     #[serde(rename(deserialize = "type", serialize = "type"))]
     pub variable_type: VariableType,
     #[serde(default = "PipelineVariableServiceType::default")]
-    pub service: PipelineVariableServiceType
+    pub service: PipelineVariableServiceType,
 }
 
 /// Model for all information about a Cloud Manager environment variable
@@ -62,8 +62,11 @@ pub struct EnvironmentVariable {
     pub value: Option<String>,
     #[serde(rename(deserialize = "type", serialize = "type"))]
     pub variable_type: VariableType,
-    #[serde(default = "EnvironmentVariableServiceType::default", skip_serializing_if = "env_var_service_type_is_default")]
-    pub service: EnvironmentVariableServiceType
+    #[serde(
+        default = "EnvironmentVariableServiceType::default",
+        skip_serializing_if = "env_var_service_type_is_default"
+    )]
+    pub service: EnvironmentVariableServiceType,
 }
 
 /// Possible types that a variable can have

--- a/src/models.rs
+++ b/src/models.rs
@@ -31,7 +31,7 @@ pub struct DomainConfig {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct EnvironmentsConfig {
     pub id: u32,
-    pub variables: Vec<Variable>,
+    pub variables: Vec<EnvironmentVariable>,
     pub domains: Option<Vec<DomainConfig>>,
 }
 
@@ -39,21 +39,31 @@ pub struct EnvironmentsConfig {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct PipelinesConfig {
     pub id: u32,
-    pub variables: Vec<Variable>,
+    pub variables: Vec<PipelineVariable>,
 }
 
 /// Model for all information about a Cloud Manager environment variable
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Variable {
+pub struct PipelineVariable {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
     #[serde(rename(deserialize = "type", serialize = "type"))]
     pub variable_type: VariableType,
-    #[serde(default = "VariableServiceType::all")]
-    pub service: VariableServiceType,
+    #[serde(default = "PipelineVariableServiceType::default")]
+    pub service: PipelineVariableServiceType
+}
+
+/// Model for all information about a Cloud Manager environment variable
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct EnvironmentVariable {
+    pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<String>,
+    pub value: Option<String>,
+    #[serde(rename(deserialize = "type", serialize = "type"))]
+    pub variable_type: VariableType,
+    #[serde(default = "EnvironmentVariableServiceType::default", skip_serializing_if = "env_var_service_type_is_default")]
+    pub service: EnvironmentVariableServiceType
 }
 
 /// Possible types that a variable can have
@@ -64,26 +74,48 @@ pub enum VariableType {
     SecretString,
 }
 
-/// Possible types that a service can have
+/// Possible service types that an environment variable can have
 #[derive(Clone, Debug, Deserialize, Serialize, IntoStaticStr, EnumString, PartialEq, Eq)]
 #[strum(serialize_all = "lowercase")]
 #[serde(rename_all = "lowercase")]
-pub enum VariableServiceType {
+pub enum EnvironmentVariableServiceType {
     All,
     Author,
     Publish,
     Preview,
 }
 
-impl fmt::Display for VariableServiceType {
+impl fmt::Display for EnvironmentVariableServiceType {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "{}", format!("{:?}", self).to_lowercase())
+    }
+}
+fn env_var_service_type_is_default(t: &EnvironmentVariableServiceType) -> bool {
+    *t == EnvironmentVariableServiceType::All
+}
+
+impl EnvironmentVariableServiceType {
+    fn default() -> Self {
+        EnvironmentVariableServiceType::All
+    }
+}
+/// Possible service types that an environment variable can have
+#[derive(Clone, Debug, Deserialize, Serialize, IntoStaticStr, EnumString, PartialEq, Eq)]
+#[strum(serialize_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
+pub enum PipelineVariableServiceType {
+    Build,
+}
+
+impl fmt::Display for crate::models::PipelineVariableServiceType {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "{}", format!("{:?}", self).to_lowercase())
     }
 }
 
-impl VariableServiceType {
-    fn all() -> Self {
-        VariableServiceType::All
+impl PipelineVariableServiceType {
+    fn default() -> Self {
+        PipelineVariableServiceType::Build
     }
 }
 
@@ -163,15 +195,28 @@ pub struct Environment {
 
 /// Struct to serialize the response of requesting /api/program/{id}/environment/{id}/variables
 #[derive(Debug, Deserialize, Serialize)]
-pub struct VariablesResponse {
+pub struct EnvironmentVariablesResponse {
     #[serde(rename(deserialize = "_embedded", serialize = "_embedded"))]
-    pub variables_list: VariablesList,
+    pub variables_list: EnvironmentVariablesList,
+}
+
+/// Struct to serialize the response of requesting /api/program/{id}/environment/{id}/variables
+#[derive(Debug, Deserialize, Serialize)]
+pub struct PipelineVariablesResponse {
+    #[serde(rename(deserialize = "_embedded", serialize = "_embedded"))]
+    pub variables_list: PipelineVariablesList,
 }
 
 /// Struct that holds a list of variables
 #[derive(Debug, Deserialize, Serialize)]
-pub struct VariablesList {
-    pub variables: Vec<Variable>,
+pub struct EnvironmentVariablesList {
+    pub variables: Vec<EnvironmentVariable>,
+}
+
+/// Struct that holds a list of variables
+#[derive(Debug, Deserialize, Serialize)]
+pub struct PipelineVariablesList {
+    pub variables: Vec<PipelineVariable>,
 }
 
 // Models for representing Cloud Manager pipelines and descendant objects

--- a/src/models.rs
+++ b/src/models.rs
@@ -42,16 +42,14 @@ pub struct PipelinesConfig {
     pub variables: Vec<PipelineVariable>,
 }
 
-/// Model for all information about a Cloud Manager environment variable
+/// Model for common cloud manager variables
+
+/// Possible types that a variable can have
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct PipelineVariable {
-    pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub value: Option<String>,
-    #[serde(rename(deserialize = "type", serialize = "type"))]
-    pub variable_type: VariableType,
-    #[serde(default = "PipelineVariableServiceType::default")]
-    pub service: PipelineVariableServiceType,
+#[serde(rename_all = "camelCase")]
+pub enum VariableType {
+    String,
+    SecretString,
 }
 
 /// Model for all information about a Cloud Manager environment variable
@@ -67,14 +65,6 @@ pub struct EnvironmentVariable {
         skip_serializing_if = "env_var_service_type_is_default"
     )]
     pub service: EnvironmentVariableServiceType,
-}
-
-/// Possible types that a variable can have
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub enum VariableType {
-    String,
-    SecretString,
 }
 
 /// Possible service types that an environment variable can have
@@ -102,7 +92,21 @@ impl EnvironmentVariableServiceType {
         EnvironmentVariableServiceType::All
     }
 }
-/// Possible service types that an environment variable can have
+
+/// Model for all information about a Cloud Manager pipeline variable
+/// Model for all information about a Cloud Manager environment variable
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PipelineVariable {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    #[serde(rename(deserialize = "type", serialize = "type"))]
+    pub variable_type: VariableType,
+    #[serde(default = "PipelineVariableServiceType::default")]
+    pub service: PipelineVariableServiceType,
+}
+
+/// Possible service types that an pipeline variable can have
 #[derive(Clone, Debug, Deserialize, Serialize, IntoStaticStr, EnumString, PartialEq, Eq)]
 #[strum(serialize_all = "lowercase")]
 #[serde(rename_all = "lowercase")]
@@ -110,7 +114,7 @@ pub enum PipelineVariableServiceType {
     Build,
 }
 
-impl fmt::Display for crate::models::PipelineVariableServiceType {
+impl fmt::Display for PipelineVariableServiceType {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "{}", format!("{:?}", self).to_lowercase())
     }

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -430,10 +430,16 @@ pub async fn set_pipeline_vars_from_file(
                     for vf in &vars_final {
                         match vf.value {
                             None => {
-                                println!("{:>8} DELETING '{}'", "✍", vf.name);
+                                println!(
+                                    "{:>8} DELETING '{}', service: {}",
+                                    "✍", vf.name, vf.service
+                                );
                             }
                             Some(_) => {
-                                println!("{:>8} UPDATING '{}'", "✍", vf.name)
+                                println!(
+                                    "{:>8} UPDATING '{}', service: {}",
+                                    "✍", vf.name, vf.service
+                                )
                             }
                         }
                     }

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -2,7 +2,10 @@ use crate::client::{AdobeConnector, CloudManagerClient};
 use crate::encryption::decrypt;
 use crate::environments::get_environment;
 use crate::errors::throw_adobe_api_error;
-use crate::models::{EnvironmentVariable, PipelineVariable, VariableType, EnvironmentVariablesList, EnvironmentVariablesResponse, YamlConfig, PipelineVariablesList, PipelineVariablesResponse};
+use crate::models::{
+    EnvironmentVariable, EnvironmentVariablesList, EnvironmentVariablesResponse, PipelineVariable,
+    PipelineVariablesList, PipelineVariablesResponse, VariableType, YamlConfig,
+};
 use crate::pipelines::get_pipeline;
 use crate::HOST_NAME;
 use colored::*;
@@ -52,8 +55,8 @@ pub async fn get_env_vars(
         .await?
         .text()
         .await?;
-    let variables: EnvironmentVariablesResponse =
-        serde_json::from_str(response.as_str()).unwrap_or_else(|_| {
+    let variables: EnvironmentVariablesResponse = serde_json::from_str(response.as_str())
+        .unwrap_or_else(|_| {
             throw_adobe_api_error(response);
             process::exit(1);
         });
@@ -188,7 +191,7 @@ pub async fn set_env_vars_from_file(
                                 name: vc.name,
                                 value: None,
                                 variable_type: vc.variable_type,
-                                service: vc.service
+                                service: vc.service,
                             };
                             vars_final.push(variable_to_be_deleted);
                         }
@@ -279,8 +282,8 @@ pub async fn get_pipeline_vars(
         .await?
         .text()
         .await?;
-    let variables: PipelineVariablesResponse =
-        serde_json::from_str(response.as_str()).unwrap_or_else(|_| {
+    let variables: PipelineVariablesResponse = serde_json::from_str(response.as_str())
+        .unwrap_or_else(|_| {
             throw_adobe_api_error(response);
             process::exit(1);
         });
@@ -418,7 +421,7 @@ pub async fn set_pipeline_vars_from_file(
                                 name: vc.name,
                                 value: None,
                                 variable_type: vc.variable_type,
-                                service: vc.service
+                                service: vc.service,
                             };
                             vars_final.push(variable_to_be_deleted);
                         }

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -14,14 +14,14 @@ use std::process;
 use std::thread::sleep;
 use std::time::Duration;
 
-// Make environment variables comparable - if they have the same name and same service they are equal.
+// Make environment variables comparable - if they have the same name and same service they are the same.
 impl PartialEq for EnvironmentVariable {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name && self.service == other.service
     }
 }
 
-// Make pipeline variables comparable - if they have the same name they are equal.
+// Make pipeline variables comparable - if they have the same name and same service they are the same.
 impl PartialEq for PipelineVariable {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name && self.service == other.service


### PR DESCRIPTION
I have detected a bug in the patching of the environment variables.
In the current implementation the check if an environment variable should be removed takes only the name into account but not the actual service type the variable is applied to.

# Example

When we first apply the following environment variable:

```
- name: VARIABLE
  value: author variable
  type: string
  service: author
```

When removing the service and applying the environment variables with

```
- name: VARIABLE
  value: author variable
  type: string
```

This led to the state that two environment variables were present in the environment and the old author environment variable was not cleaned up.

I have now changed the implementation and we are now also using the applied service during envaluation what environment variables need to be updated / deleted.

Since the pipeline variables looked like they will also get additional service / steps soon (currently only `build` is available) I have also adjusted the logic for the pipeline variable update.

Since I have introduced a `enum` for possible environment variable services and due to the new added service support for pipeline variables I had to separate the environment variables from the pipeline variables.

I have now also added an optional `--dry-run` flag which allows a preview of what the environment / pipeline variable step will do.