### PR TITLE
Add invalid variable service type for environments and pipelines

### DIFF
--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -12,7 +12,7 @@ use crate::client::CloudManagerClient;
 use crate::config::CloudManagerConfig;
 use crate::encryption::{decrypt, encrypt};
 use crate::logs::{download_log, tail_log};
-use crate::models::{Domain, LogType, PipelineVariableServiceType, ServiceType};
+use crate::models::{Domain, LogType, PipelineVariableServiceType, EnvironmentVariableServiceType, ServiceType};
 use crate::variables::{
     get_env_vars, get_pipeline_vars, set_env_vars_from_file, set_pipeline_vars_from_file,
 };

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -95,6 +95,17 @@ pub async fn init_cli() {
                                     .await
                                     .unwrap();
                                 println!("{}", serde_json::to_string_pretty(&env_vars).unwrap());
+                                if let Some(vf) = env_vars.variables.iter().find(|vf| {
+                                    vf.service == EnvironmentVariableServiceType::Invalid
+                                }) {
+                                    eprintln!(
+                                        "{:>8} {}  '{}: {}'",
+                                        "⚠".yellow(),
+                                        "WARN, invalid service type detected for variable".yellow(),
+                                        vf.name,
+                                        vf.service
+                                    );
+                                }
                             }
                         } else {
                             eprintln!("❌ You have to provide a valid Cloud Manager environment ID to run this command!");

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -12,7 +12,7 @@ use crate::client::CloudManagerClient;
 use crate::config::CloudManagerConfig;
 use crate::encryption::{decrypt, encrypt};
 use crate::logs::{download_log, tail_log};
-use crate::models::{Domain, LogType, ServiceType};
+use crate::models::{Domain, LogType, PipelineVariableServiceType, ServiceType};
 use crate::variables::{
     get_env_vars, get_pipeline_vars, set_env_vars_from_file, set_pipeline_vars_from_file,
 };
@@ -283,10 +283,24 @@ pub async fn init_cli() {
                                     get_pipeline_vars(&mut cm_client, program_id, &pipeline_id)
                                         .await
                                         .unwrap();
+
                                 println!(
                                     "{}",
                                     serde_json::to_string_pretty(&pipeline_vars).unwrap()
                                 );
+                                if let Some(vf) = pipeline_vars
+                                    .variables
+                                    .iter()
+                                    .find(|vf| vf.service == PipelineVariableServiceType::Invalid)
+                                {
+                                    eprintln!(
+                                        "{:>8} {}  '{}: {}'",
+                                        "⚠".yellow(),
+                                        "WARN, invalid service type detected for variable".yellow(),
+                                        vf.name,
+                                        vf.service
+                                    );
+                                }
                             }
                         } else {
                             eprintln!("❌ You have to provide a valid Cloud Manager pipeline ID to run this command!");

--- a/src/models.rs
+++ b/src/models.rs
@@ -82,7 +82,11 @@ pub enum EnvironmentVariableServiceType {
 
 impl fmt::Display for EnvironmentVariableServiceType {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "{}", format!("{:?}", self).to_lowercase())
+        write!(
+            formatter,
+            "{}",
+            format!("{}", serde_json::to_string(self).unwrap().to_string())
+        )
     }
 }
 fn environment_variable_skip_serializing(t: &EnvironmentVariableServiceType) -> bool {
@@ -122,7 +126,11 @@ pub enum PipelineVariableServiceType {
 
 impl fmt::Display for PipelineVariableServiceType {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "{}", format!("{:?}", self).to_lowercase())
+        write!(
+            formatter,
+            "{}",
+            format!("{}", serde_json::to_string(self).unwrap().to_string())
+        )
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -62,7 +62,7 @@ pub struct EnvironmentVariable {
     pub variable_type: VariableType,
     #[serde(
         default = "EnvironmentVariableServiceType::default",
-        skip_serializing_if = "env_var_service_type_is_default"
+        skip_serializing_if = "environment_variable_skip_serializing"
     )]
     pub service: EnvironmentVariableServiceType,
 }
@@ -76,6 +76,8 @@ pub enum EnvironmentVariableServiceType {
     Author,
     Publish,
     Preview,
+    #[serde(other)]
+    Invalid,
 }
 
 impl fmt::Display for EnvironmentVariableServiceType {
@@ -83,7 +85,7 @@ impl fmt::Display for EnvironmentVariableServiceType {
         write!(formatter, "{}", format!("{:?}", self).to_lowercase())
     }
 }
-fn env_var_service_type_is_default(t: &EnvironmentVariableServiceType) -> bool {
+fn environment_variable_skip_serializing(t: &EnvironmentVariableServiceType) -> bool {
     *t == EnvironmentVariableServiceType::All
 }
 
@@ -102,7 +104,9 @@ pub struct PipelineVariable {
     pub value: Option<String>,
     #[serde(rename(deserialize = "type", serialize = "type"))]
     pub variable_type: VariableType,
-    #[serde(default = "PipelineVariableServiceType::default")]
+    #[serde(
+        default = "PipelineVariableServiceType::default"
+    )]
     pub service: PipelineVariableServiceType,
 }
 
@@ -112,6 +116,8 @@ pub struct PipelineVariable {
 #[serde(rename_all = "lowercase")]
 pub enum PipelineVariableServiceType {
     Build,
+    #[serde(other)]
+    Invalid
 }
 
 impl fmt::Display for PipelineVariableServiceType {

--- a/src/models.rs
+++ b/src/models.rs
@@ -108,9 +108,7 @@ pub struct PipelineVariable {
     pub value: Option<String>,
     #[serde(rename(deserialize = "type", serialize = "type"))]
     pub variable_type: VariableType,
-    #[serde(
-        default = "PipelineVariableServiceType::default"
-    )]
+    #[serde(default = "PipelineVariableServiceType::default")]
     pub service: PipelineVariableServiceType,
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -116,12 +116,14 @@ pub struct PipelineVariable {
 
 /// Possible service types that an pipeline variable can have
 #[derive(Clone, Debug, Deserialize, Serialize, IntoStaticStr, EnumString, PartialEq, Eq)]
-#[strum(serialize_all = "lowercase")]
-#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 pub enum PipelineVariableServiceType {
     Build,
+    UiTest,
+    FunctionalTest,
     #[serde(other)]
-    Invalid
+    Invalid,
 }
 
 impl fmt::Display for PipelineVariableServiceType {

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -198,6 +198,17 @@ pub async fn set_env_vars_from_file(
                     }
 
                     for vf in &vars_final {
+                        // check if service is invalid and error exit when this is the case.
+                        if vf.service == EnvironmentVariableServiceType::Invalid {
+                            eprintln!(
+                                "{:>8} {} '{}'",
+                                "❌".red(),
+                                "Error, invalid service type detected for variable ".red(),
+                                vf.name
+                            );
+                            process::exit(3);
+                        }
+
                         match vf.value {
                             None => {
                                 println!(
@@ -428,6 +439,17 @@ pub async fn set_pipeline_vars_from_file(
                     }
 
                     for vf in &vars_final {
+                        // check if service is invalid and error exit when this is the case.
+                        if vf.service == PipelineVariableServiceType::Invalid {
+                            eprintln!(
+                                "{:>8} {} '{}'",
+                                "❌".red(),
+                                "Error, invalid service type detected for variable ".red(),
+                                vf.name
+                            );
+                            process::exit(3);
+                        }
+
                         match vf.value {
                             None => {
                                 println!(

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -3,7 +3,8 @@ use crate::encryption::decrypt;
 use crate::environments::get_environment;
 use crate::errors::throw_adobe_api_error;
 use crate::models::{
-    EnvironmentVariable, EnvironmentVariablesList, EnvironmentVariablesResponse, PipelineVariable,
+    EnvironmentVariable, EnvironmentVariableServiceType, EnvironmentVariablesList,
+    EnvironmentVariablesResponse, PipelineVariable, PipelineVariableServiceType,
     PipelineVariablesList, PipelineVariablesResponse, VariableType, YamlConfig,
 };
 use crate::pipelines::get_pipeline;

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -198,18 +198,21 @@ pub async fn set_env_vars_from_file(
                         }
                     }
 
-                    for vf in &vars_final {
-                        // check if service is invalid and error exit when this is the case.
-                        if vf.service == EnvironmentVariableServiceType::Invalid {
-                            eprintln!(
-                                "{:>8} {} '{}'",
-                                "❌".red(),
-                                "Error, invalid service type detected for variable ".red(),
-                                vf.name
-                            );
-                            process::exit(3);
-                        }
+                    if let Some(vf) = vars_final
+                        .iter()
+                        .find(|vf| vf.service == EnvironmentVariableServiceType::Invalid)
+                    {
+                        eprintln!(
+                            "{:>8} {}  '{}: {}'",
+                            "❌".red(),
+                            "ERROR, invalid service type detected for variable".red(),
+                            vf.name,
+                            vf.service
+                        );
+                        process::exit(3);
+                    }
 
+                    for vf in &vars_final {
                         match vf.value {
                             None => {
                                 println!(
@@ -439,18 +442,21 @@ pub async fn set_pipeline_vars_from_file(
                         }
                     }
 
-                    for vf in &vars_final {
-                        // check if service is invalid and error exit when this is the case.
-                        if vf.service == PipelineVariableServiceType::Invalid {
-                            eprintln!(
-                                "{:>8} {} '{}'",
-                                "❌".red(),
-                                "Error, invalid service type detected for variable ".red(),
-                                vf.name
-                            );
-                            process::exit(3);
-                        }
+                    if let Some(vf) = vars_final
+                        .iter()
+                        .find(|vf| vf.service == PipelineVariableServiceType::Invalid)
+                    {
+                        eprintln!(
+                            "{:>8} {}  '{}: {}'",
+                            "❌".red(),
+                            "ERROR, invalid service type detected for variable".red(),
+                            vf.name,
+                            vf.service
+                        );
+                        process::exit(3);
+                    }
 
+                    for vf in &vars_final {
                         match vf.value {
                             None => {
                                 println!(


### PR DESCRIPTION
This PR enhances the resilience of #37 and ensure that 
* existing pipeline or environment variables with invalid service types to not lead to a rust exception
* no invalid service types can be set anymore