### PR TITLE
Add unittests for environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    # branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@
 /target
 /pippo.json
 /public
-/test*

--- a/src/models/variables.rs
+++ b/src/models/variables.rs
@@ -262,7 +262,7 @@ mod tests {
             name: String::from("authorVarName"),
             variable_type: VariableType::String,
             service: EnvironmentVariableServiceType::All,
-            value: Some(String::from("authorVarValue"))
+            value: Some(String::from("authorVarValue")),
         };
         let under_test: String = serde_json::to_string(&variable).unwrap();
         assert_eq!(
@@ -277,7 +277,7 @@ mod tests {
             name: String::from("publishVarName"),
             variable_type: VariableType::SecretString,
             service: EnvironmentVariableServiceType::Publish,
-            value: Some(String::from("publishValue"))
+            value: Some(String::from("publishValue")),
         };
         let under_test: String = serde_json::to_string(&variable).unwrap();
         assert_eq!(
@@ -292,7 +292,7 @@ mod tests {
             name: String::from("previewVarName"),
             variable_type: VariableType::String,
             service: EnvironmentVariableServiceType::Preview,
-            value: Some(String::from("previewValue"))
+            value: Some(String::from("previewValue")),
         };
         let under_test: String = serde_json::to_string(&variable).unwrap();
         assert_eq!(

--- a/src/models/variables.rs
+++ b/src/models/variables.rs
@@ -255,4 +255,49 @@ mod tests {
         );
         assert_eq!(under_test.variable_type, VariableType::String,);
     }
+
+    #[test]
+    fn serialize_author_service_environment_variable() {
+        let variable: EnvironmentVariable = EnvironmentVariable {
+            name: String::from("authorVarName"),
+            variable_type: VariableType::String,
+            service: EnvironmentVariableServiceType::All,
+            value: Some(String::from("authorVarValue"))
+        };
+        let under_test: String = serde_json::to_string(&variable).unwrap();
+        assert_eq!(
+            under_test,
+            "{\"name\":\"authorVarName\",\"value\":\"authorVarValue\",\"type\":\"string\"}",
+        );
+    }
+
+    #[test]
+    fn serialize_publish_service_environment_variable() {
+        let variable: EnvironmentVariable = EnvironmentVariable {
+            name: String::from("publishVarName"),
+            variable_type: VariableType::SecretString,
+            service: EnvironmentVariableServiceType::Publish,
+            value: Some(String::from("publishValue"))
+        };
+        let under_test: String = serde_json::to_string(&variable).unwrap();
+        assert_eq!(
+            under_test,
+            "{\"name\":\"publishVarName\",\"value\":\"publishValue\",\"type\":\"secretString\",\"service\":\"publish\"}",
+        );
+    }
+
+    #[test]
+    fn serialize_preview_service_environment_variable() {
+        let variable: EnvironmentVariable = EnvironmentVariable {
+            name: String::from("previewVarName"),
+            variable_type: VariableType::String,
+            service: EnvironmentVariableServiceType::Preview,
+            value: Some(String::from("previewValue"))
+        };
+        let under_test: String = serde_json::to_string(&variable).unwrap();
+        assert_eq!(
+            under_test,
+            "{\"name\":\"previewVarName\",\"value\":\"previewValue\",\"type\":\"string\",\"service\":\"preview\"}",
+        );
+    }
 }

--- a/src/models/variables.rs
+++ b/src/models/variables.rs
@@ -1,11 +1,12 @@
-use serde::{Deserialize, Serialize};
+use serde::de::Visitor;
+use serde::{de, Deserialize, Deserializer, Serialize};
 use std::fmt;
 use strum_macros::{EnumString, IntoStaticStr};
 
 /// Model for common cloud manager variables
 
 /// Possible types that a variable can have
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum VariableType {
     String,
@@ -28,7 +29,7 @@ pub struct EnvironmentVariable {
 }
 
 /// Possible service types that an environment variable can have
-#[derive(Clone, Debug, Deserialize, Serialize, IntoStaticStr, EnumString, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, IntoStaticStr, EnumString, PartialEq, Eq)]
 #[strum(serialize_all = "lowercase")]
 #[serde(rename_all = "lowercase")]
 pub enum EnvironmentVariableServiceType {
@@ -51,6 +52,38 @@ impl fmt::Display for EnvironmentVariableServiceType {
 }
 fn environment_variable_skip_serializing(t: &EnvironmentVariableServiceType) -> bool {
     *t == EnvironmentVariableServiceType::All
+}
+
+impl<'de> serde::Deserialize<'de> for EnvironmentVariableServiceType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct EnvVarVisitor;
+
+        impl<'de> Visitor<'de> for EnvVarVisitor {
+            type Value = EnvironmentVariableServiceType;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a string representing an environment variable service type")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                match value {
+                    "" => Ok(EnvironmentVariableServiceType::All), // Handle empty string as `All`
+                    "author" => Ok(EnvironmentVariableServiceType::Author),
+                    "publish" => Ok(EnvironmentVariableServiceType::Publish),
+                    "preview" => Ok(EnvironmentVariableServiceType::Preview),
+                    _ => Ok(EnvironmentVariableServiceType::Invalid),
+                }
+            }
+        }
+
+        deserializer.deserialize_str(EnvVarVisitor)
+    }
 }
 
 impl EnvironmentVariableServiceType {
@@ -124,4 +157,102 @@ pub struct EnvironmentVariablesList {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct PipelineVariablesList {
     pub variables: Vec<PipelineVariable>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::tests::read_json_from_file;
+
+    #[test]
+    fn deserialize_all_service_environment_variable() {
+        let vobj: EnvironmentVariablesResponse =
+            read_json_from_file("test/variables/environment_variables_response.json").unwrap();
+
+        let under_test: &EnvironmentVariable = vobj.variables_list.variables.get(0).unwrap();
+        assert_eq!(under_test.service, EnvironmentVariableServiceType::All,);
+        assert_eq!(under_test.name, "VARIABLE",);
+        assert_eq!(
+            under_test
+                .value
+                .clone()
+                .unwrap_or("default string".to_string()),
+            "no service specified",
+        );
+        assert_eq!(under_test.variable_type, VariableType::String,);
+    }
+
+    #[test]
+    fn deserialize_empty_service_environment_variable() {
+        let vobj: EnvironmentVariablesResponse =
+            read_json_from_file("test/variables/environment_variables_response.json").unwrap();
+
+        let under_test: &EnvironmentVariable = vobj.variables_list.variables.get(1).unwrap();
+        assert_eq!(under_test.service, EnvironmentVariableServiceType::All,);
+        assert_eq!(under_test.name, "SECRET_VARIABLE",);
+        assert_eq!(
+            under_test.value.clone().unwrap_or("no_value".to_string()),
+            "no_value",
+        );
+        assert_eq!(under_test.variable_type, VariableType::SecretString,);
+    }
+
+    #[test]
+    fn deserialize_publish_service_environment_variable() {
+        let vobj: EnvironmentVariablesResponse =
+            read_json_from_file("test/variables/environment_variables_response.json").unwrap();
+
+        let under_test: &EnvironmentVariable = vobj.variables_list.variables.get(3).unwrap();
+        assert_eq!(under_test.service, EnvironmentVariableServiceType::Publish,);
+        assert_eq!(under_test.name, "VARIABLE",);
+        assert_eq!(
+            under_test.value.clone().unwrap_or("no_value".to_string()),
+            "publish variable",
+        );
+        assert_eq!(under_test.variable_type, VariableType::String,);
+    }
+
+    #[test]
+    fn deserialize_author_service_environment_variable() {
+        let vobj: EnvironmentVariablesResponse =
+            read_json_from_file("test/variables/environment_variables_response.json").unwrap();
+
+        let under_test: &EnvironmentVariable = vobj.variables_list.variables.get(4).unwrap();
+        assert_eq!(under_test.service, EnvironmentVariableServiceType::Author,);
+        assert_eq!(under_test.name, "SECRET_VARIABLE",);
+        assert_eq!(
+            under_test.value.clone().unwrap_or("no_value".to_string()),
+            "no_value",
+        );
+        assert_eq!(under_test.variable_type, VariableType::SecretString,);
+    }
+
+    #[test]
+    fn deserialize_preview_service_environment_variable() {
+        let vobj: EnvironmentVariablesResponse =
+            read_json_from_file("test/variables/environment_variables_response.json").unwrap();
+
+        let under_test: &EnvironmentVariable = vobj.variables_list.variables.get(2).unwrap();
+        assert_eq!(under_test.service, EnvironmentVariableServiceType::Preview,);
+        assert_eq!(under_test.name, "VARIABLE",);
+        assert_eq!(
+            under_test.value.clone().unwrap_or("no_value".to_string()),
+            "preview variable",
+        );
+        assert_eq!(under_test.variable_type, VariableType::String,);
+    }
+    #[test]
+    fn deserialize_invalid_service_environment_variable() {
+        let vobj: EnvironmentVariablesResponse =
+            read_json_from_file("test/variables/environment_variables_response.json").unwrap();
+
+        let under_test: &EnvironmentVariable = vobj.variables_list.variables.get(7).unwrap();
+        assert_eq!(under_test.service, EnvironmentVariableServiceType::Invalid,);
+        assert_eq!(under_test.name, "INVALID_SERVICE_VARIABLE",);
+        assert_eq!(
+            under_test.value.clone().unwrap_or("no_value".to_string()),
+            "invalid service variable",
+        );
+        assert_eq!(under_test.variable_type, VariableType::String,);
+    }
 }

--- a/test/variables/environment_variables_response.json
+++ b/test/variables/environment_variables_response.json
@@ -1,0 +1,70 @@
+{
+  "_links": {
+    "http://ns.adobe.com/adobecloud/rel/environment": {
+      "href": "/api/program/111111/environment/2222222"
+    },
+    "http://ns.adobe.com/adobecloud/rel/program": {
+      "href": "/api/program/111111",
+      "templated": false
+    },
+    "self": {
+      "href": "/api/program/111111/environment/2222222/variables"
+    }
+  },
+  "_embedded": {
+    "variables": [
+      {
+        "name": "VARIABLE",
+        "value": "no service specified",
+        "type": "string",
+        "status": "ready"
+      },
+      {
+        "name": "SECRET_VARIABLE",
+        "type": "secretString",
+        "service": "",
+        "status": "ready"
+      },
+      {
+        "name": "VARIABLE",
+        "value": "preview variable",
+        "type": "string",
+        "service": "preview",
+        "status": "ready"
+      },
+      {
+        "name": "VARIABLE",
+        "value": "publish variable",
+        "type": "string",
+        "service": "publish",
+        "status": "ready"
+      },
+      {
+        "name": "SECRET_VARIABLE",
+        "type": "secretString",
+        "service": "author",
+        "status": "ready"
+      },
+      {
+        "name": "SECRET_VARIABLE",
+        "type": "secretString",
+        "service": "publish",
+        "status": "ready"
+      },
+      {
+        "name": "SSECRET_VARIABLE",
+        "type": "secretString",
+        "service": "preview",
+        "status": "ready"
+      },
+      {
+        "name": "INVALID_SERVICE_VARIABLE",
+        "value": "invalid service variable",
+        "type": "string",
+        "service": "lorem",
+        "status": "ready"
+      }
+    ]
+  },
+  "_totalNumberOfItems": 8
+}


### PR DESCRIPTION
Fix deserializing empty `service: ""` to `all` service.