### PR TITLE
Add pagination support to domain list

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,11 @@ pippo -c <pippo.json> env vars set --ci <environment-variables.yml>
 The current state of implementation is only creating new domains. It will not update nor delete other domains.
 In case a domain is already there, error ALREADY_IN_USE is shown.
 
-#### Example Data:
+#### List arguments
+
+You can provide `--start` and limit `--limit` to `domain list` in order to limit / page the results.
+
+#### Example Data
 
 ```yaml
 ---
@@ -317,6 +321,8 @@ programs:
 
 ```bash
 pippo -c <pippo.json> -p <program-id> domain list
+pippo -c <pippo.json> -p <program-id> domain list --start 0 --limit 20 
+pippo -c <pippo.json> -p <program-id> domain list --start 20 -- limit 20
 pippo -c <pippo.json> domain create <environment-domains.yml>
 ```
 

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ programs:
 ```bash
 pippo -c <pippo.json> -p <program-id> domain list
 pippo -c <pippo.json> -p <program-id> domain list --start 0 --limit 20 
-pippo -c <pippo.json> -p <program-id> domain list --start 20 -- limit 20
+pippo -c <pippo.json> -p <program-id> domain list --start 20 --limit 20
 pippo -c <pippo.json> domain create <environment-domains.yml>
 ```
 

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -180,10 +180,11 @@ pub async fn init_cli() {
                 // Since all "domain" subcommands need a program ID, we can only run them when it was provided.
                 if let Some(program_id) = cli.program {
                     match &domain_command {
-                        DomainCommands::List => {
-                            let domains = domains::get_domains(&mut cm_client, program_id)
-                                .await
-                                .unwrap();
+                        DomainCommands::List { start, limit } => {
+                            let domains =
+                                domains::get_domains(&mut cm_client, program_id, start, limit)
+                                    .await
+                                    .unwrap();
                             if let Some(env_id) = cli.env {
                                 let env_i64 = env_id as i64;
                                 let filtered_domains: Vec<Domain> = domains

--- a/src/clap_models.rs
+++ b/src/clap_models.rs
@@ -192,8 +192,16 @@ pub enum PipelineVarsCommands {
 
 #[derive(Subcommand)]
 pub enum DomainCommands {
-    /// List all pipelines of the specified program
-    List,
+    /// List all domains of the specified program
+    List {
+        /// Pagination start parameter
+        #[clap(short, long, value_parser, default_value_t = 0)]
+        start: u32,
+        /// Pagination limit parameter
+        #[clap(short, long, value_parser, default_value_t = 1000)]
+        limit: u32,
+    },
+    /// Creates domains based upon a provided file
     Create {
         #[clap(value_parser, value_name = "FILE")]
         input: String,

--- a/src/domains.rs
+++ b/src/domains.rs
@@ -7,6 +7,7 @@ extern crate uuid;
 use colored::Colorize;
 use reqwest::{Error, Method, StatusCode};
 use std::process;
+use std::str;
 use uuid::Uuid;
 
 /// Retrieves all domains.
@@ -24,10 +25,20 @@ use uuid::Uuid;
 pub async fn get_domains(
     client: &mut CloudManagerClient,
     program_id: u32,
+    start: &u32,
+    limit: &u32,
 ) -> Result<DomainList, Error> {
     let request_path = format!("{}/api/program/{}/domainNames", HOST_NAME, program_id);
+    let query_start: &str = &start.to_string();
+    let query_limit: &str = &limit.to_string();
+    let query_parameters = vec![("start", query_start), ("limit", query_limit)];
     let response = client
-        .perform_request(Method::GET, request_path, None::<()>, None)
+        .perform_request(
+            Method::GET,
+            request_path,
+            None::<()>,
+            Some(query_parameters),
+        )
         .await?
         .text()
         .await?;


### PR DESCRIPTION
I noticed that the `domain list` only returns 20 domains.
I have now added `--limit` and `--start` arguments for `domain list` and increased the default limit to `1000`