### PR TITLE
Add support for deploy step pipeline variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ programs:
         variables:
           - name: FOO
             value: bar
-            type: string            
+            type: string
           - name: SECRET_FOO
             value: $enc2 muchEncryptedString
             type: secretString

--- a/README.md
+++ b/README.md
@@ -310,10 +310,11 @@ programs:
         variables:
           - name: FOO
             value: bar
-            type: string
+            type: string            
           - name: SECRET_FOO
             value: $enc2 muchEncryptedString
             type: secretString
+            service: deploy
 ```
 
 ### Logs

--- a/src/models/variables.rs
+++ b/src/models/variables.rs
@@ -107,6 +107,7 @@ pub struct PipelineVariable {
 pub enum PipelineVariableServiceType {
     Build,
     UiTest,
+    Deploy,
     FunctionalTest,
     #[serde(other)]
     Invalid,

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -84,8 +84,11 @@ impl Hash for PipelineVariableServiceType {
             PipelineVariableServiceType::UiTest => {
                 state.write_u8(3);
             }
-            PipelineVariableServiceType::Invalid => {
+            PipelineVariableServiceType::Deploy => {
                 state.write_u8(4);
+            }
+            PipelineVariableServiceType::Invalid => {
+                state.write_u8(5);
             }
         }
     }


### PR DESCRIPTION
Config deployment pipelines need the variables in the `deploy` build step so I added support for that.