### PR TITLE
feat: add Adobe content requests download support with JSON/CSV export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,6 +758,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2191,6 +2212,7 @@ dependencies = [
  "chrono",
  "clap 3.2.25",
  "colored",
+ "csv",
  "env_logger",
  "flate2",
  "futures-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ headers = "0.4.1"
 rustls = "0.23.40"
 anyhow = "1.0.102"
 http = "1.4.0"
+csv = "1.3"
 [dependencies.reqwest]
 version = "0.12.28"
 #default-features = false

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ It enables you to
  * create Domains
  * manage OV and EV certificates
  * get an access token which can be reused e.g. by `curl` commands in CI/CD pipelines
+ * download Adobe Content Requests usage
+ * ingest Adobe Content Requests usage into OpenSearch
 
 ## Installation
 
@@ -328,6 +330,66 @@ programs:
 pippo -c <pippo.json> -p <program-id> -e <environment-id> log save --service <svc> --log <log> --date <YYYY-MM-DD>
 pippo -c <pippo.json> -p <program-id> -e <environment-id> log tail --service <svc> --log <log>
 ```
+
+### Content Requests
+
+* Download Adobe Content Requests usage
+* Export results as JSON or CSV
+* Ingest Adobe Content Requests usage into OpenSearch
+
+It is possible to pass the program ID by setting the environment variable `PIPPO_PROGRAM_ID`.
+
+#### JSON export
+
+```bash
+pippo -c <pippo.json> -p <program-id> content-requests download \
+  --start-date 2026-01-01 \
+  --end-date 2026-06-30 \
+  --time-unit daily \
+  --format json
+```
+#### CSV export
+
+```bash
+pippo -c <pippo.json> -p <program-id> content-requests download \
+  --start-date 2026-01-01 \
+  --end-date 2026-06-30 \
+  --time-unit monthly \
+  --format csv \
+  --output content-requests.csv
+```
+
+#### OpenSearch ingestion
+
+- The target OpenSearch index must already exist and is supplied using the `--opensearch-index` option.
+
+- When connecting to a local OpenSearch instance with a self-signed certificate, use the `--insecure` option.
+
+```bash
+pippo -c <pippo.json> -p <program-id> content-requests ingest \
+  --start-date 2026-01-01 \
+  --end-date 2026-06-30 \
+  --time-unit daily \
+  --opensearch-url <opensearch-url> \
+  --opensearch-index <opensearch-index> \
+  --opensearch-username <username> \
+  --opensearch-password <password>
+```
+
+#### Options
+
+| Option | Description | Applies to |
+|--------|-------------|------------|
+| `--start-date` | Start date in `YYYY-MM-DD` format | Download, Ingest |
+| `--end-date` | End date in `YYYY-MM-DD` format | Download, Ingest |
+| `--time-unit` | Aggregation interval: `daily` or `monthly` | Download, Ingest |
+| `--format` | Output format: `json` or `csv` | Download |
+| `--output` | Output file path | Download |
+| `--opensearch-url` | OpenSearch endpoint | Ingest |
+| `--opensearch-index` | Target OpenSearch index | Ingest |
+| `--opensearch-username` | OpenSearch username | Ingest |
+| `--opensearch-password` | OpenSearch password | Ingest |
+| `--insecure` | Skip TLS certificate validation | Ingest |
 
 ### dry-run mode
 

--- a/README.md
+++ b/README.md
@@ -387,9 +387,22 @@ pippo -c <pippo.json> -p <program-id> content-requests ingest \
 | `--output` | Output file path | Download |
 | `--opensearch-url` | OpenSearch endpoint | Ingest |
 | `--opensearch-index` | Target OpenSearch index | Ingest |
-| `--opensearch-username` | OpenSearch username | Ingest |
-| `--opensearch-password` | OpenSearch password | Ingest |
+| `--opensearch-username` | OpenSearch username (or environment variable `OPENSEARCH_USERNAME`) | Ingest |
+| `--opensearch-password` | OpenSearch password (or environment variable `OPENSEARCH_PASSWORD`) | Ingest |
 | `--insecure` | Skip TLS certificate validation | Ingest |
+
+Instead of passing `--opensearch-username` and `--opensearch-password` on the command line, you can provide them via the `OPENSEARCH_USERNAME` and `OPENSEARCH_PASSWORD`environment variables.
+
+#### Example usage
+
+```bash
+pippo content-requests ingest \
+  --opensearch-url "$OPENSEARCH_URL" \
+  --opensearch-index "$OPENSEARCH_INDEX" \
+  --start-date 2026-06-01 \
+  --end-date 2026-07-01 \
+  --time-unit daily
+```
 
 ### dry-run mode
 

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -16,6 +16,7 @@ use crate::logs::{download_log, tail_log};
 use crate::models::domain::Domain;
 use crate::models::log::{LogType, ServiceType};
 use crate::models::variables::{EnvironmentVariableServiceType, PipelineVariableServiceType};
+use crate::opensearch;
 
 use crate::models::certificates::CertificateList;
 use crate::variables::{
@@ -414,6 +415,39 @@ pub async fn init_cli() {
                 } else {
                     println!("{}", content);
                 }
+            }
+
+            ContentRequestsCommands::Ingest {
+                start_date,
+                end_date,
+                time_unit,
+                program_name,
+                opensearch_url,
+                opensearch_index,
+                opensearch_username,
+                opensearch_password,
+                insecure,
+            } => {
+                let records = content_requests::download_content_requests(
+                    &mut cm_client,
+                    start_date,
+                    end_date,
+                    time_unit,
+                    program_name.as_deref(),
+                )
+                .await
+                .unwrap();
+
+                opensearch::ingest_content_requests(
+                    &records,
+                    opensearch_url,
+                    opensearch_index,
+                    opensearch_username,
+                    opensearch_password,
+                    *insecure,
+                )
+                .await
+                .unwrap();
             }
         },
 

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -380,24 +380,28 @@ pub async fn init_cli() {
                 time_unit,
                 format,
                 output,
-                program_name,
             } => {
-                let response = content_requests::download_content_requests(
+                let program_id_filter = cli
+                    .program
+                    .as_ref()
+                    .map(|program_id| program_id.to_string());
+
+                let records = content_requests::download_content_requests(
                     &mut cm_client,
                     start_date,
                     end_date,
                     time_unit,
-                    program_name.as_deref(),
+                    program_id_filter.as_deref(),
                 )
                 .await
                 .unwrap();
 
                 let content = match format.as_str() {
-                    "json" => serde_json::to_string_pretty(&response).unwrap(),
+                    "json" => serde_json::to_string_pretty(&records).unwrap(),
                     "csv" => {
                         let mut writer = csv::Writer::from_writer(vec![]);
 
-                        for record in &response {
+                        for record in &records {
                             writer.serialize(record).unwrap();
                         }
 
@@ -421,19 +425,23 @@ pub async fn init_cli() {
                 start_date,
                 end_date,
                 time_unit,
-                program_name,
                 opensearch_url,
                 opensearch_index,
                 opensearch_username,
                 opensearch_password,
                 insecure,
             } => {
+                let program_id_filter = cli
+                    .program
+                    .as_ref()
+                    .map(|program_id| program_id.to_string());
+
                 let records = content_requests::download_content_requests(
                     &mut cm_client,
                     start_date,
                     end_date,
                     time_unit,
-                    program_name.as_deref(),
+                    program_id_filter.as_deref(),
                 )
                 .await
                 .unwrap();

--- a/src/clap_app.rs
+++ b/src/clap_app.rs
@@ -10,6 +10,7 @@ use crate::auth::obtain_access_token;
 use crate::clap_models::*;
 use crate::client::CloudManagerClient;
 use crate::config::CloudManagerConfig;
+use crate::content_requests;
 use crate::encryption::{decrypt, encrypt_marked};
 use crate::logs::{download_log, tail_log};
 use crate::models::domain::Domain;
@@ -368,6 +369,53 @@ pub async fn init_cli() {
                 );
             }
         }
+
+        Some(Commands::ContentRequests {
+            content_requests_command,
+        }) => match &content_requests_command {
+            ContentRequestsCommands::Download {
+                start_date,
+                end_date,
+                time_unit,
+                format,
+                output,
+                program_name,
+            } => {
+                let response = content_requests::download_content_requests(
+                    &mut cm_client,
+                    start_date,
+                    end_date,
+                    time_unit,
+                    program_name.as_deref(),
+                )
+                .await
+                .unwrap();
+
+                let content = match format.as_str() {
+                    "json" => serde_json::to_string_pretty(&response).unwrap(),
+                    "csv" => {
+                        let mut writer = csv::Writer::from_writer(vec![]);
+
+                        for record in &response {
+                            writer.serialize(record).unwrap();
+                        }
+
+                        String::from_utf8(writer.into_inner().unwrap()).unwrap()
+                    }
+                    _ => {
+                        eprintln!("❌ Unsupported format: {}", format);
+                        process::exit(1);
+                    }
+                };
+
+                if let Some(output) = output {
+                    std::fs::write(output, content).unwrap();
+                    println!("✅ Content request usage written to {}", output);
+                } else {
+                    println!("{}", content);
+                }
+            }
+        },
 
         _ => {}
     }

--- a/src/clap_models.rs
+++ b/src/clap_models.rs
@@ -100,6 +100,12 @@ pub enum Commands {
         #[clap(subcommand)]
         certificate_command: CertificateCommands,
     },
+
+    /// Tools to retrieve Adobe content request usage
+    ContentRequests {
+        #[clap(subcommand)]
+        content_requests_command: ContentRequestsCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -229,5 +235,35 @@ pub enum CertificateCommands {
     Manage {
         #[clap(value_parser, value_name = "FILE")]
         input: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum ContentRequestsCommands {
+    /// Download Adobe content request usage
+    Download {
+        /// Start date in YYYY-MM-DD format
+        #[clap(long, value_parser, value_name = "YYYY-MM-DD")]
+        start_date: String,
+
+        /// End date in YYYY-MM-DD format
+        #[clap(long, value_parser, value_name = "YYYY-MM-DD")]
+        end_date: String,
+
+        /// Time unit: daily or monthly
+        #[clap(long, value_parser, possible_values = vec!["daily", "monthly"], default_value = "monthly")]
+        time_unit: String,
+
+        /// Output format: json or csv
+        #[clap(long, value_parser, possible_values = vec!["json", "csv"], default_value = "json")]
+        format: String,
+
+        /// Output file path
+        #[clap(short, long, value_parser)]
+        output: Option<String>,
+
+        /// Filter by program name
+        #[clap(long, value_parser)]
+        program_name: Option<String>,
     },
 }

--- a/src/clap_models.rs
+++ b/src/clap_models.rs
@@ -283,10 +283,10 @@ pub enum ContentRequestsCommands {
         #[clap(long, value_parser)]
         opensearch_index: String,
 
-        #[clap(long, value_parser)]
+        #[clap(long, value_parser, env = "OPENSEARCH_USERNAME")]
         opensearch_username: String,
 
-        #[clap(long, value_parser)]
+        #[clap(long, value_parser, env = "OPENSEARCH_PASSWORD")]
         opensearch_password: String,
 
         #[clap(long, action = ArgAction::SetTrue)]

--- a/src/clap_models.rs
+++ b/src/clap_models.rs
@@ -261,10 +261,6 @@ pub enum ContentRequestsCommands {
         /// Output file path
         #[clap(short, long, value_parser)]
         output: Option<String>,
-
-        /// Filter by program name
-        #[clap(long, value_parser)]
-        program_name: Option<String>,
     },
 
     /// Ingest Adobe content request usage into OpenSearch
@@ -281,14 +277,10 @@ pub enum ContentRequestsCommands {
         #[clap(long, value_parser, possible_values = vec!["daily", "monthly"], default_value = "monthly")]
         time_unit: String,
 
-        /// Filter by program name
-        #[clap(long, value_parser)]
-        program_name: Option<String>,
-
         #[clap(long, value_parser, default_value = "https://localhost:9200")]
         opensearch_url: String,
 
-        #[clap(long, value_parser, default_value = "aem-content-requests-test")]
+        #[clap(long, value_parser)]
         opensearch_index: String,
 
         #[clap(long, value_parser)]

--- a/src/clap_models.rs
+++ b/src/clap_models.rs
@@ -266,4 +266,38 @@ pub enum ContentRequestsCommands {
         #[clap(long, value_parser)]
         program_name: Option<String>,
     },
+
+    /// Ingest Adobe content request usage into OpenSearch
+    Ingest {
+        /// Start date in YYYY-MM-DD format
+        #[clap(long, value_parser, value_name = "YYYY-MM-DD")]
+        start_date: String,
+
+        /// End date in YYYY-MM-DD format
+        #[clap(long, value_parser, value_name = "YYYY-MM-DD")]
+        end_date: String,
+
+        /// Time unit: daily or monthly
+        #[clap(long, value_parser, possible_values = vec!["daily", "monthly"], default_value = "monthly")]
+        time_unit: String,
+
+        /// Filter by program name
+        #[clap(long, value_parser)]
+        program_name: Option<String>,
+
+        #[clap(long, value_parser, default_value = "https://localhost:9200")]
+        opensearch_url: String,
+
+        #[clap(long, value_parser, default_value = "aem-content-requests-test")]
+        opensearch_index: String,
+
+        #[clap(long, value_parser)]
+        opensearch_username: String,
+
+        #[clap(long, value_parser)]
+        opensearch_password: String,
+
+        #[clap(long, action = ArgAction::SetTrue)]
+        insecure: bool,
+    },
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -23,6 +23,16 @@ pub trait AdobeConnector {
     ) -> Result<Response, Error>
     where
         T: Serialize + Send;
+
+    async fn perform_assets_reporting_request<T>(
+        &mut self,
+        method: Method,
+        path: String,
+        body: Option<T>,
+        query: Option<Vec<(&str, &str)>>,
+    ) -> Result<Response, Error>
+    where
+        T: Serialize + Send;
 }
 
 #[async_trait]
@@ -55,6 +65,48 @@ impl AdobeConnector for CloudManagerClient {
             .header("x-api-key", &self.config.client_id);
 
         // Add query parameters (if any)
+        if let Some(params) = query {
+            req = req.query(&params);
+        }
+
+        match method {
+            Method::POST | Method::PUT | Method::PATCH => {
+                if let Some(b) = body {
+                    req = req.json(&b);
+                }
+            }
+            _ => {}
+        }
+
+        let response = req.send().await?;
+        Ok(response)
+    }
+
+    /// Issues HTTP requests to Adobe Assets Reporting APIs.
+    ///
+    /// This endpoint requires `x-api-key: ssp_ui` instead of the normal Pippo client ID.
+    async fn perform_assets_reporting_request<T>(
+        &mut self,
+        method: Method,
+        path: String,
+        body: Option<T>,
+        query: Option<Vec<(&str, &str)>>,
+    ) -> Result<Response, Error>
+    where
+        T: Serialize + Send,
+    {
+        let mut req = self.client.request(method.clone(), &path);
+
+        req = req
+            .header(AUTHORIZATION, &self.config.authorization_header)
+            .header("x-gw-ims-org-id", &self.config.organization_id)
+            .header("x-api-key", "ssp_ui")
+            .header("accept", "application/json, text/plain, */*")
+            .header("cache-control", "no-cache")
+            .header("pragma", "no-cache")
+            .header("origin", "https://cdn.experience.adobe.net")
+            .header("referer", "https://cdn.experience.adobe.net/");
+
         if let Some(params) = query {
             req = req.query(&params);
         }

--- a/src/content_requests.rs
+++ b/src/content_requests.rs
@@ -1,65 +1,18 @@
 use crate::client::{AdobeConnector, CloudManagerClient};
+use crate::models::content_requests::{ContentRequestsRecord, ContentRequestsResponse};
 use crate::ASSETS_REPORTING_HOST_NAME;
 use chrono::{Duration, NaiveDate};
 use reqwest::Method;
-use serde::{Deserialize, Serialize};
 
-const DAILY_SLICE_DAYS: i64 = 90;
-const MONTHLY_SLICE_DAYS: i64 = 365;
-
-#[derive(Debug, Deserialize)]
-pub struct ContentRequestsResponse {
-    pub data: ContentRequestsData,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct ContentRequestsData {
-    pub programs: Vec<ContentRequestsProgram>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct ContentRequestsProgram {
-    pub name: String,
-    pub usage: Vec<ContentRequestsUsage>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct ContentRequestsUsage {
-    #[serde(rename = "apiCalls")]
-    pub api_calls: u64,
-
-    #[serde(rename = "contentRequests")]
-    pub content_requests: u64,
-
-    pub date: String,
-
-    #[serde(rename = "pageViews")]
-    pub page_views: u64,
-}
-
-#[derive(Debug, Serialize)]
-pub struct ContentRequestsRecord {
-    pub date: String,
-
-    #[serde(rename = "programName")]
-    pub program_name: String,
-
-    #[serde(rename = "apiCalls")]
-    pub api_calls: u64,
-
-    #[serde(rename = "contentRequests")]
-    pub content_requests: u64,
-
-    #[serde(rename = "pageViews")]
-    pub page_views: u64,
-}
+const DAILY_SLICE_DAYS: i64 = 60;
+const MONTHLY_SLICE_DAYS: i64 = 360;
 
 pub async fn download_content_requests(
     client: &mut CloudManagerClient,
     start_date: &str,
     end_date: &str,
     time_unit: &str,
-    program_name_filter: Option<&str>,
+    program_id_filter: Option<&str>,
 ) -> Result<Vec<ContentRequestsRecord>, reqwest::Error> {
     let slice_days = if time_unit == "daily" {
         DAILY_SLICE_DAYS
@@ -76,7 +29,7 @@ pub async fn download_content_requests(
             &slice_start,
             &slice_end,
             time_unit,
-            program_name_filter,
+            program_id_filter,
         )
         .await?;
 
@@ -91,7 +44,7 @@ async fn download_content_requests_slice(
     start_date: &str,
     end_date: &str,
     time_unit: &str,
-    program_name_filter: Option<&str>,
+    program_id_filter: Option<&str>,
 ) -> Result<Vec<ContentRequestsRecord>, reqwest::Error> {
     let path = format!(
         "{}/statistics/contentRequestsUsage",
@@ -110,7 +63,7 @@ async fn download_content_requests_slice(
 
     let parsed = response.json::<ContentRequestsResponse>().await?;
 
-    Ok(flatten_content_requests(parsed, program_name_filter))
+    Ok(flatten_content_requests(parsed, program_id_filter))
 }
 
 fn build_date_slices(start_date: &str, end_date: &str, slice_days: i64) -> Vec<(String, String)> {
@@ -136,14 +89,15 @@ fn build_date_slices(start_date: &str, end_date: &str, slice_days: i64) -> Vec<(
 
 fn flatten_content_requests(
     response: ContentRequestsResponse,
-    program_name_filter: Option<&str>,
+    program_id_filter: Option<&str>,
 ) -> Vec<ContentRequestsRecord> {
     response
         .data
         .programs
         .into_iter()
-        .filter(|program| program_name_filter.is_none_or(|name| program.name == name))
+        .filter(|program| program_id_filter.is_none_or(|id| program.id.to_string() == id))
         .flat_map(|program| {
+            let program_id = program.id;
             let program_name = program.name;
 
             program
@@ -151,6 +105,7 @@ fn flatten_content_requests(
                 .into_iter()
                 .map(move |usage| ContentRequestsRecord {
                     date: format!("{}T00:00:00Z", usage.date),
+                    program_id,
                     program_name: program_name.clone(),
                     api_calls: usage.api_calls,
                     content_requests: usage.content_requests,
@@ -171,11 +126,11 @@ mod tests {
         assert_eq!(slices.len(), 2);
         assert_eq!(
             slices[0],
-            ("2025-01-01".to_string(), "2025-03-31".to_string())
+            ("2025-01-01".to_string(), "2025-03-01".to_string())
         );
         assert_eq!(
             slices[1],
-            ("2025-04-01".to_string(), "2025-04-15".to_string())
+            ("2025-03-02".to_string(), "2025-04-15".to_string())
         );
     }
 
@@ -186,11 +141,11 @@ mod tests {
         assert_eq!(slices.len(), 2);
         assert_eq!(
             slices[0],
-            ("2025-01-01".to_string(), "2025-12-31".to_string())
+            ("2025-01-01".to_string(), "2025-12-26".to_string())
         );
         assert_eq!(
             slices[1],
-            ("2026-01-01".to_string(), "2026-03-31".to_string())
+            ("2025-12-27".to_string(), "2026-03-31".to_string())
         );
     }
 }

--- a/src/content_requests.rs
+++ b/src/content_requests.rs
@@ -1,0 +1,196 @@
+use crate::client::{AdobeConnector, CloudManagerClient};
+use crate::ASSETS_REPORTING_HOST_NAME;
+use chrono::{Duration, NaiveDate};
+use reqwest::Method;
+use serde::{Deserialize, Serialize};
+
+const DAILY_SLICE_DAYS: i64 = 90;
+const MONTHLY_SLICE_DAYS: i64 = 365;
+
+#[derive(Debug, Deserialize)]
+pub struct ContentRequestsResponse {
+    pub data: ContentRequestsData,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ContentRequestsData {
+    pub programs: Vec<ContentRequestsProgram>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ContentRequestsProgram {
+    pub name: String,
+    pub usage: Vec<ContentRequestsUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ContentRequestsUsage {
+    #[serde(rename = "apiCalls")]
+    pub api_calls: u64,
+
+    #[serde(rename = "contentRequests")]
+    pub content_requests: u64,
+
+    pub date: String,
+
+    #[serde(rename = "pageViews")]
+    pub page_views: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ContentRequestsRecord {
+    pub date: String,
+
+    #[serde(rename = "programName")]
+    pub program_name: String,
+
+    #[serde(rename = "apiCalls")]
+    pub api_calls: u64,
+
+    #[serde(rename = "contentRequests")]
+    pub content_requests: u64,
+
+    #[serde(rename = "pageViews")]
+    pub page_views: u64,
+}
+
+pub async fn download_content_requests(
+    client: &mut CloudManagerClient,
+    start_date: &str,
+    end_date: &str,
+    time_unit: &str,
+    program_name_filter: Option<&str>,
+) -> Result<Vec<ContentRequestsRecord>, reqwest::Error> {
+    let slice_days = if time_unit == "daily" {
+        DAILY_SLICE_DAYS
+    } else {
+        MONTHLY_SLICE_DAYS
+    };
+
+    let ranges = build_date_slices(start_date, end_date, slice_days);
+    let mut records: Vec<ContentRequestsRecord> = Vec::new();
+
+    for (slice_start, slice_end) in ranges {
+        let mut slice_records = download_content_requests_slice(
+            client,
+            &slice_start,
+            &slice_end,
+            time_unit,
+            program_name_filter,
+        )
+        .await?;
+
+        records.append(&mut slice_records);
+    }
+
+    Ok(records)
+}
+
+async fn download_content_requests_slice(
+    client: &mut CloudManagerClient,
+    start_date: &str,
+    end_date: &str,
+    time_unit: &str,
+    program_name_filter: Option<&str>,
+) -> Result<Vec<ContentRequestsRecord>, reqwest::Error> {
+    let path = format!(
+        "{}/statistics/contentRequestsUsage",
+        ASSETS_REPORTING_HOST_NAME
+    );
+
+    let query = vec![
+        ("startDate", start_date),
+        ("endDate", end_date),
+        ("timeUnit", time_unit),
+    ];
+
+    let response = client
+        .perform_assets_reporting_request::<()>(Method::GET, path, None, Some(query))
+        .await?;
+
+    let parsed = response.json::<ContentRequestsResponse>().await?;
+
+    Ok(flatten_content_requests(parsed, program_name_filter))
+}
+
+fn build_date_slices(start_date: &str, end_date: &str, slice_days: i64) -> Vec<(String, String)> {
+    let start = NaiveDate::parse_from_str(start_date, "%Y-%m-%d").unwrap();
+    let end = NaiveDate::parse_from_str(end_date, "%Y-%m-%d").unwrap();
+
+    let mut ranges = Vec::new();
+    let mut current_start = start;
+
+    while current_start <= end {
+        let current_end = std::cmp::min(current_start + Duration::days(slice_days - 1), end);
+
+        ranges.push((
+            current_start.format("%Y-%m-%d").to_string(),
+            current_end.format("%Y-%m-%d").to_string(),
+        ));
+
+        current_start = current_end + Duration::days(1);
+    }
+
+    ranges
+}
+
+fn flatten_content_requests(
+    response: ContentRequestsResponse,
+    program_name_filter: Option<&str>,
+) -> Vec<ContentRequestsRecord> {
+    response
+        .data
+        .programs
+        .into_iter()
+        .filter(|program| program_name_filter.map_or(true, |name| program.name == name))
+        .flat_map(|program| {
+            let program_name = program.name;
+
+            program
+                .usage
+                .into_iter()
+                .map(move |usage| ContentRequestsRecord {
+                    date: format!("{}T00:00:00Z", usage.date),
+                    program_name: program_name.clone(),
+                    api_calls: usage.api_calls,
+                    content_requests: usage.content_requests,
+                    page_views: usage.page_views,
+                })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_daily_slices() {
+        let slices = build_date_slices("2025-01-01", "2025-04-15", DAILY_SLICE_DAYS);
+
+        assert_eq!(slices.len(), 2);
+        assert_eq!(
+            slices[0],
+            ("2025-01-01".to_string(), "2025-03-31".to_string())
+        );
+        assert_eq!(
+            slices[1],
+            ("2025-04-01".to_string(), "2025-04-15".to_string())
+        );
+    }
+
+    #[test]
+    fn builds_monthly_slices() {
+        let slices = build_date_slices("2025-01-01", "2026-03-31", MONTHLY_SLICE_DAYS);
+
+        assert_eq!(slices.len(), 2);
+        assert_eq!(
+            slices[0],
+            ("2025-01-01".to_string(), "2025-12-31".to_string())
+        );
+        assert_eq!(
+            slices[1],
+            ("2026-01-01".to_string(), "2026-03-31".to_string())
+        );
+    }
+}

--- a/src/content_requests.rs
+++ b/src/content_requests.rs
@@ -142,7 +142,7 @@ fn flatten_content_requests(
         .data
         .programs
         .into_iter()
-        .filter(|program| program_name_filter.map_or(true, |name| program.name == name))
+        .filter(|program| program_name_filter.is_none_or(|name| program.name == name))
         .flat_map(|program| {
             let program_name = program.name;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod errors;
 mod execution;
 mod logs;
 mod models;
+mod opensearch;
 mod pipelines;
 mod programs;
 mod variables;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod clap_app;
 mod clap_models;
 mod client;
 mod config;
+mod content_requests;
 mod domains;
 mod encryption;
 mod environments;
@@ -30,6 +31,7 @@ use crate::clap_app::init_cli;
 
 const HOST_NAME: &str = "https://cloudmanager.adobe.io";
 const IMS_ENDPOINT: &str = "ims-na1.adobelogin.com";
+const ASSETS_REPORTING_HOST_NAME: &str = "https://assets-reporting.adobe.io";
 
 #[tokio::main]
 async fn main() {

--- a/src/models/content_requests.rs
+++ b/src/models/content_requests.rs
@@ -1,0 +1,52 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+pub struct ContentRequestsResponse {
+    pub data: ContentRequestsData,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ContentRequestsData {
+    pub programs: Vec<ContentRequestsProgram>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ContentRequestsProgram {
+    pub id: u32,
+    pub name: String,
+    pub usage: Vec<ContentRequestsUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ContentRequestsUsage {
+    #[serde(rename = "apiCalls")]
+    pub api_calls: u64,
+
+    #[serde(rename = "contentRequests")]
+    pub content_requests: u64,
+
+    pub date: String,
+
+    #[serde(rename = "pageViews")]
+    pub page_views: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ContentRequestsRecord {
+    pub date: String,
+
+    #[serde(rename = "programId")]
+    pub program_id: u32,
+
+    #[serde(rename = "programName")]
+    pub program_name: String,
+
+    #[serde(rename = "apiCalls")]
+    pub api_calls: u64,
+
+    #[serde(rename = "contentRequests")]
+    pub content_requests: u64,
+
+    #[serde(rename = "pageViews")]
+    pub page_views: u64,
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod certificates;
 pub mod config;
+pub mod content_requests;
 pub mod domain;
 pub mod environment;
 pub mod execution;

--- a/src/opensearch.rs
+++ b/src/opensearch.rs
@@ -1,0 +1,53 @@
+use crate::content_requests::ContentRequestsRecord;
+use anyhow::Result;
+use serde_json::json;
+
+pub async fn ingest_content_requests(
+    records: &[ContentRequestsRecord],
+    opensearch_url: &str,
+    opensearch_index: &str,
+    opensearch_username: &str,
+    opensearch_password: &str,
+    insecure: bool,
+) -> Result<()> {
+    let mut payload = String::new();
+
+    for record in records {
+        payload.push_str(&serde_json::to_string(&json!({
+            "index": {
+                "_index": opensearch_index,
+                "_id": format!("{}-{}", record.program_name, record.date)
+            }
+        }))?);
+        payload.push('\n');
+
+        payload.push_str(&serde_json::to_string(&json!({
+            "@timestamp": record.date,
+            "programName": record.program_name,
+            "apiCalls": record.api_calls,
+            "contentRequests": record.content_requests,
+            "pageViews": record.page_views
+        }))?);
+        payload.push('\n');
+    }
+
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(insecure)
+        .build()?;
+
+    let response = client
+        .post(format!("{}/_bulk", opensearch_url.trim_end_matches('/')))
+        .basic_auth(opensearch_username, Some(opensearch_password))
+        .header("Content-Type", "application/x-ndjson")
+        .body(payload)
+        .send()
+        .await?;
+
+    let status = response.status();
+    let body = response.text().await?;
+
+    println!("OpenSearch status: {}", status);
+    println!("{}", body);
+
+    Ok(())
+}

--- a/src/opensearch.rs
+++ b/src/opensearch.rs
@@ -1,4 +1,4 @@
-use crate::content_requests::ContentRequestsRecord;
+use crate::models::content_requests::ContentRequestsRecord;
 use anyhow::Result;
 use serde_json::json;
 
@@ -16,13 +16,14 @@ pub async fn ingest_content_requests(
         payload.push_str(&serde_json::to_string(&json!({
             "index": {
                 "_index": opensearch_index,
-                "_id": format!("{}-{}", record.program_name, record.date)
+                "_id": format!("p{}-{}", record.program_id, record.date)
             }
         }))?);
         payload.push('\n');
 
         payload.push_str(&serde_json::to_string(&json!({
             "@timestamp": record.date,
+            "programId": record.program_id,
             "programName": record.program_name,
             "apiCalls": record.api_calls,
             "contentRequests": record.content_requests,


### PR DESCRIPTION
feat: implement content requests API integration

- add Adobe Assets Reporting API support
- add content-requests CLI command
- support JSON and CSV output formats
- add automatic request slicing for large date ranges
- flatten response structure
- add optional program-name filtering