### PR TITLE
refactor: optimize variable containment check and remove redundant clones

### DIFF
--- a/src/models/variables.rs
+++ b/src/models/variables.rs
@@ -88,7 +88,6 @@ impl EnvironmentVariableServiceType {
 }
 
 /// Model for all information about a Cloud Manager pipeline variable
-/// Model for all information about a Cloud Manager environment variable
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PipelineVariable {
     pub name: String,

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -257,7 +257,7 @@ pub async fn set_env_vars_from_file(
                                 // - $enc2 <...> / $enc2<...> (new scheme)
                                 // - $enc <...>  / $enc<...>  (legacy scheme, with fallback)
                                 // - raw base64 (tries new first, then legacy)
-                                let tmp_loop_var_value = tmp_loop_var.clone().value.unwrap();
+                                let tmp_loop_var_value = tmp_loop_var.value.clone().unwrap();
                                 if tmp_loop_var_value.starts_with("$enc") {
                                     tmp_loop_var.value = Some(decrypt(tmp_loop_var_value));
                                 }
@@ -268,9 +268,12 @@ pub async fn set_env_vars_from_file(
 
                     // If a variable is only present on Cloud Manager and not in the YAML, then we
                     // will set its value to None and push it to vars_final, so it will be deleted.
+                    // Build a set for O(1) lookup instead of scanning the vec on every iteration.
+                    let vars_yaml_set: HashSet<EnvironmentVariable> =
+                        vars_yaml.iter().cloned().collect();
                     let vars_cloud = get_env_vars(client, p.id, e.id).await.unwrap().variables;
                     for vc in vars_cloud {
-                        if !vars_yaml.clone().contains(&vc) {
+                        if !vars_yaml_set.contains(&vc) {
                             let variable_to_be_deleted = EnvironmentVariable {
                                 name: vc.name,
                                 value: None,
@@ -515,7 +518,7 @@ pub async fn set_pipeline_vars_from_file(
                                 // - $enc2 <...> / $enc2<...> (new scheme)
                                 // - $enc <...>  / $enc<...>  (legacy scheme, with fallback)
                                 // - raw base64 (tries new first, then legacy)
-                                let tmp_loop_var_value = tmp_loop_var.clone().value.unwrap();
+                                let tmp_loop_var_value = tmp_loop_var.value.clone().unwrap();
                                 if tmp_loop_var_value.starts_with("$enc") {
                                     tmp_loop_var.value = Some(decrypt(tmp_loop_var_value));
                                 }
@@ -526,12 +529,15 @@ pub async fn set_pipeline_vars_from_file(
 
                     // If a variable is only present on Cloud Manager and not in the YAML, then we
                     // will set its value to None and push it to vars_final, so it will be deleted.
+                    // Build a set for O(1) lookup instead of scanning the vec on every iteration.
+                    let vars_yaml_set: HashSet<PipelineVariable> =
+                        vars_yaml.iter().cloned().collect();
                     let vars_cloud = get_pipeline_vars(client, p.id, &l.id)
                         .await
                         .unwrap()
                         .variables;
                     for vc in vars_cloud {
-                        if !vars_yaml.clone().contains(&vc) {
+                        if !vars_yaml_set.contains(&vc) {
                             let variable_to_be_deleted = PipelineVariable {
                                 name: vc.name,
                                 value: None,


### PR DESCRIPTION
spotted a couple of small things while reviewing the deploy step pipeline variables change

- `tmp_loop_var.clone().value.unwrap()` clones the whole struct just to read one field, changed to `tmp_loop_var.value.clone().unwrap()`
- `vars_yaml.clone().contains(&vc)` inside the cloud var loop is O(n²), replaced with a HashSet built once before the loop for O(1) lookup
- removed a copy-paste docstring on PipelineVariable that was referencing EnvironmentVariable

all 24 tests pass